### PR TITLE
Add nuclear-data-reader to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of open source projects used in nuclear science and engineering.
 - [SANDY](https://github.com/luca-fiorito-11/sandy) — Sampling tool for nuclear data
 - [SCALE](https://code.ornl.gov/scale/code/scale-public) — Public components of SCALE (AMPX, SAMMY)
 - [TALYS](https://nds.iaea.org/talys) — Nuclear Reaction Simulator Code
+- [Nuclear Data Reader](https://github.com/php1ic/nuclear-data-reader) - C++ library for parsing NUBASE and AME data files
 
 ## Depletion / Transmutation / Decay
 


### PR DESCRIPTION
Can I please request my project is added to this list.

It reads the data files published by [AMDC](https://www-nds.iaea.org/amdc/index.html) for isotopic masses, half-lives, separation energies and Q-values.

You can either load it into memory and access it as part of your C++ code, or write the data in json format and use those files in a separate project.