### PR TITLE
Add OpenMCyclus to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A curated list of open source projects used in nuclear science and engineering.
 ## Fuel Cycle
 
 - [Cyclus](https://github.com/cyclus/cyclus) — Nuclear fuel cycle simulator
+- [OpenMCyclus](https://github.com/arfc/openmcyclus) — Depletable reactor archetype using OpenMCs `IndepednentOperator` for fuel cycle simulations in Cyclus.
 
 ## Thermal Hydraulics
 


### PR DESCRIPTION
This PR adds [OpenMCyclus](https://github.com/arfc/openmcyclus) to the list. OpenMCyclus is an archetype library for Cyclus that adds `DepleteReactor` that couples to OpenMC's depletion module. For faster calculations, `DepleteReactor` uses OpenMC's `IndepednentOperator` to deplete materials based on a user-provided power and flux profile.