### PR TITLE
add Dakota

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of open source projects used in nuclear science and engineering.
 ## Other
 
 - [ARMI](https://github.com/terrapower/armi) — Reactor analysis automation framework
+- [Dakota](https://github.com/snl-dakota/dakota) — software for optimization and UQ
 - [NRIC Virtual Test Bed](https://github.com/idaholab/virtual_test_bed) — Repository of example challenge problems
 - [PyNE](https://github.com/pyne/pyne) — Python/C++ nuclear engineering toolkit
 - [RAVEN](https://github.com/idaholab/raven) — UQ, regression, PRA, data analysis, and model optimization framework


### PR DESCRIPTION
Hi,

I propose adding [Dakota](https://github.com/snl-dakota/dakota) to the list.
It is used for various optimization, uncertainty quantification and sensitivity analysis tasks. Used not only in nuclear engineering.

Developed by SNL, open-sourced at GitHub. 

By the way, do we prefer to add links to the source code repository or to the webpages of the project? I assumed the former.